### PR TITLE
Add id check to users.js and tests to prevent updating other people's accounts

### DIFF
--- a/api/controllers/users.js
+++ b/api/controllers/users.js
@@ -25,6 +25,10 @@ const update = async (req, res) => {
   const { email, password } = req.body
   const { id } = req.params
 
+  if (req.userId !== id) {
+    return res.status(400).json({ message: 'You cannot update someone elses account'})
+  }
+
   const { emailErrors, passwordErrors } = validateFields(email, password)
   if (emailErrors.length !== 0 || passwordErrors.length !== 0 ) {
     return res.status(400).json({ passwordErrors, emailErrors })

--- a/api/tests/controllers/users.test.js
+++ b/api/tests/controllers/users.test.js
@@ -201,6 +201,50 @@ describe("/users", () => {
       expect(foundUser.email).toEqual("someone@example.com");
       expect(foundUser.password).toEqual("Something1?");
     })
+
+    it("cannot change someone else's password", async () => {
+      const user1 = await User.create({
+        email: "userone1@example.com",
+        password: "User1password!"
+      })
+      const user2 = await User.create({
+        email: "usertwo2@example.com",
+        password: "User2password!"
+      })
+      const user1token = createToken(user1._id)
+      const response = await request(app)
+        .put(`/users/${user2._id}`)
+        .set("Authorization", `Bearer ${user1token}`)
+        .send({ password: "User1password!" });
+      expect(response.statusCode).toBe(400)
+      const users = await User.find();
+      expect(users[0].email).toEqual("userone1@example.com");
+      expect(users[0].password).toEqual("User1password!");
+      expect(users[1].email).toEqual("usertwo2@example.com");
+      expect(users[1].password).toEqual("User2password!");
+    })
+
+    it("cannot change someone else's email", async () => {
+      const user1 = await User.create({
+        email: "userone1@example.com",
+        password: "User1password!"
+      })
+      const user2 = await User.create({
+        email: "usertwo2@example.com",
+        password: "User2password!"
+      })
+      const user1token = createToken(user1._id)
+      const response = await request(app)
+        .put(`/users/${user2._id}`)
+        .set("Authorization", `Bearer ${user1token}`)
+        .send({ email: "goodlucklogginginnow@gmail.com"});
+      expect(response.statusCode).toBe(400)
+      const users = await User.find();
+      expect(users[0].email).toEqual("userone1@example.com");
+      expect(users[0].password).toEqual("User1password!");
+      expect(users[1].email).toEqual("usertwo2@example.com");
+      expect(users[1].password).toEqual("User2password!");
+    })
   })
 
   describe('PUT, when no token is provided', () => {
@@ -228,27 +272,6 @@ describe("/users", () => {
 
       expect(response.status).toEqual(401);
       expect(response.body.message).toEqual('auth error');
-    })
-
-    it("cannot change someone else's password", async () => {
-      const user1 = await User.create({
-        email: "userone1@example.com",
-        password: "User1password!"
-      })
-      const user2 = await User.create({
-        email: "usertwo2@example.com",
-        password: "User2password!"
-      })
-      const user1token = createToken(user1._id)
-      const response = await request(app)
-        .put(`/users/${user2._id}`)
-        .set("Authorization", `Bearer ${user1token}`)
-        .send({ password: "User1password!" });
-      const users = await User.find();
-      expect(users[0].email).toEqual("userone1@example.com");
-      expect(users[0].password).toEqual("User1password!");
-      expect(users[1].email).toEqual("usertwo2@example.com");
-      expect(users[1].password).toEqual("User2password!");
     })
   })
 


### PR DESCRIPTION
- Add two more unit tests to users.test.js to ensure that there is a 400 response when a user attempts to create an account with an invalid email/password
- Add ID check to users.js to return 400 if user attempts to update someone else's account
- Add two unit tests to ensure 400 is returned if user attempts to update someone else's account